### PR TITLE
Make direnv consenual, clear

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake . --option system x86_64-darwin

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,6 @@
+# For automatic Nix shell loading & unloading
+use flake
+
+# For automatic Nix shell for Apple’s M-series processors
+# (requires Rosetta 2 translation from x86)
+#use flake . --option system x86_64-darwin

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .direnv
+.envrc
 result
 /output
 

--- a/README.md
+++ b/README.md
@@ -68,3 +68,13 @@ This repo implements https://github.com/purs-nix/purs-nix/issues/36 but outside 
 ### IDE support
 
 Run `purs-nix compile` to compile your sources, producing an `./output` directory. This directory, in turn, will be used by the PureScript language server. This is tested to work with VSCode.
+
+### direnv
+
+To automatically load and unload the Nix shell environment, when entering the project, an `.envrc` can be used to invoke the Nix shell (as well as other things you may want in your development environement; see [direnv’s docs](https://direnv.net/)). A minimal example is provided:
+
+``` sh-session
+❯ cp .envrc.example .envrc
+❯ $EDITOR .envrc
+❯ direnv allow
+```


### PR DESCRIPTION
When I initially `cd`’d into this project directory, `direnv` started asking me if I want to source someone else’s `.envrc`. I never want this behavior because it’s not specific to my machine—and in this case it would have been a _bad_ idea because NixOS does _not_ need to run Darwin x86 binaries. If I need to make changes for my specific environment, now I have to remember _not_ to check in my changes to the `.envrc` as well as needing to be wary if other users are making modifications that negatively impact my environment (so it should be `.gitignored`’d).

A better approach would be to put in an example file that users can read over to understand what’s needed for their specific environent as well as add other features `direnv` can provide such as setting environment varibles for the host/port for a dev server, etc.

Included a spot in the README about how to set this up (including invoking the user’s editor to entice them to read what is actually _in_ the example file and, for instance, uncomment the Darwin x86 line if that is applicable to their environment).